### PR TITLE
Fix localized error log keys

### DIFF
--- a/StikJIT/Views/HomeView.swift
+++ b/StikJIT/Views/HomeView.swift
@@ -169,12 +169,12 @@ struct HomeView: View {
                         }
                         RunLoop.current.add(progressTimer, forMode: .common)
                     } catch {
-                        print(NSLocalizedString("Error copying file" + ": ", comment: ""), error)
+                        print("\(NSLocalizedString("Error copying file", comment: "")): \(error)")
                     }
                 }
                 if accessing { url.stopAccessingSecurityScopedResource() }
             case .failure(let error):
-                print(NSLocalizedString("Failed to import file" + ": ", comment: ""), error)
+                print("\(NSLocalizedString("Failed to import file", comment: "")): \(error)")
             }
         }
         .sheet(isPresented: $isShowingInstalledApps) {


### PR DESCRIPTION
## Summary
- build error log messages in `HomeView` using localized keys and string interpolation instead of dynamically concatenated keys

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d05457783c832ba31392b75f4cac02